### PR TITLE
Windows sockets 2

### DIFF
--- a/dummy_headers/windows.h
+++ b/dummy_headers/windows.h
@@ -1,5 +1,6 @@
 typedef void* SOCKET;
 typedef unsigned int DWORD;
+typedef unsigned int GROUP;
 #define WSA_FLAG_OVERLAPPED 1
 extern void WSASetLastError(int);
 extern int WSAGetLastError();
@@ -8,7 +9,7 @@ extern int WSAGetLastError();
 #define AF_INET 33
 #define SOCK_STREAM 44
 #define IPPROTO_TCP 55
-#define INVALID_SOCKET 0
+#define INVALID_SOCKET (SOCKET)(~0)
 extern void* socket(int, int, int);
 struct sockaddr_in {
     int sin_family;
@@ -16,16 +17,15 @@ struct sockaddr_in {
     unsigned short sin_port;
 };
 struct sockaddr { int dummy; };
-typedef unsigned socklen_t;
 #define SOL_SOCKET 66
 #define SO_REUSEADDR 77
 #define INADDR_LOOPBACK 88
-extern int setsockopt(SOCKET, int, int, char*, unsigned);
-extern int bind(SOCKET, struct sockaddr*, unsigned);
-extern int getsockname(SOCKET, struct sockaddr*, socklen_t*);
+extern int setsockopt(SOCKET, int, int, const char*, int);
+extern int bind(SOCKET, const struct sockaddr*, int);
+extern int getsockname(SOCKET, struct sockaddr*, int*);
 extern int listen(SOCKET, int);
-extern SOCKET WSASocket(int, int, int, void*, int, int);
-extern int connect(SOCKET, struct sockaddr*, unsigned);
-extern SOCKET accept(SOCKET, void*, void*);
+extern SOCKET WSASocket(int, int, int, void*, GROUP, DWORD);
+extern int connect(SOCKET, const struct sockaddr*, int);
+extern SOCKET accept(SOCKET, struct sockaddr*, int*);
 extern int closesocket(SOCKET);
-extern unsigned htonl(unsigned);
+extern unsigned long htonl(unsigned long);

--- a/socketpair.c
+++ b/socketpair.c
@@ -89,7 +89,7 @@ int dumb_socketpair(SOCKET socks[2], int make_overlapped)
     socks[0] = socks[1] = -1;
 
     listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    if (listener == -1)
+    if (listener == INVALID_SOCKET)
         return SOCKET_ERROR;
 
     memset(&a, 0, sizeof(a));
@@ -99,7 +99,7 @@ int dumb_socketpair(SOCKET socks[2], int make_overlapped)
 
     for (;;) {
         if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR,
-               (char*) &reuse, (socklen_t) sizeof(reuse)) == -1)
+               (char*) &reuse, (socklen_t) sizeof(reuse)) == SOCKET_ERROR)
             break;
         if  (bind(listener, &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
             break;
@@ -116,13 +116,13 @@ int dumb_socketpair(SOCKET socks[2], int make_overlapped)
             break;
 
         socks[0] = WSASocket(AF_INET, SOCK_STREAM, 0, NULL, 0, flags);
-        if (socks[0] == -1)
+        if (socks[0] == INVALID_SOCKET)
             break;
         if (connect(socks[0], &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
             break;
 
         socks[1] = accept(listener, NULL, NULL);
-        if (socks[1] == -1)
+        if (socks[1] == INVALID_SOCKET)
             break;
 
         closesocket(listener);


### PR DESCRIPTION
Change type of some variables and return values, in accordance with the [Windows Socket 2](https://docs.microsoft.com/en-us/windows/win32/winsock/) documentation.

https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-accept
```c
SOCKET WSAAPI accept(
  [in]      SOCKET   s,
  [out]     sockaddr *addr,
  [in, out] int      *addrlen
);
```
https://docs.microsoft.com/windows/win32/api/winsock/nf-winsock-bind
```c
int bind(
  [in] SOCKET         s,
       const sockaddr *addr,
  [in] int            namelen
);
```
https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-connect
```c
int WSAAPI connect(
  [in] SOCKET         s,
  [in] const sockaddr *name,
  [in] int            namelen
);
```
https://docs.microsoft.com/windows/win32/api/winsock/nf-winsock-getsockname
```c
int getsockname(
  [in]      SOCKET   s,
  [out]     sockaddr *name,
  [in, out] int      *namelen
);
```
https://docs.microsoft.com/windows/win32/api/winsock/nf-winsock-setsockopt
```c
int setsockopt(
  [in] SOCKET     s,
  [in] int        level,
  [in] int        optname,
  [in] const char *optval,
  [in] int        optlen
);
```
https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-wsasocketa
https://docs.microsoft.com/windows/win32/api/winsock2/nf-winsock2-wsasocketw
```c
SOCKET WSAAPI WSASocketA(
  [in] int                 af,
  [in] int                 type,
  [in] int                 protocol,
  [in] LPWSAPROTOCOL_INFOA lpProtocolInfo,
  [in] GROUP               g,
  [in] DWORD               dwFlags
);

SOCKET WSAAPI WSASocketW(
  [in] int                 af,
  [in] int                 type,
  [in] int                 protocol,
  [in] LPWSAPROTOCOL_INFOW lpProtocolInfo,
  [in] GROUP               g,
  [in] DWORD               dwFlags
);
```